### PR TITLE
feat: add egm maps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+data/egm96_5min.pgm filter=lfs diff=lfs merge=lfs -text
+data/*.pgm filter=lfs diff=lfs merge=lfs -text
+data/*.png filter=lfs diff=lfs merge=lfs -text
+data/*.tif filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@ data/egm96_5min.pgm filter=lfs diff=lfs merge=lfs -text
 data/*.pgm filter=lfs diff=lfs merge=lfs -text
 data/*.png filter=lfs diff=lfs merge=lfs -text
 data/*.tif filter=lfs diff=lfs merge=lfs -text
+data/egm96-15.png filter=lfs diff=lfs merge=lfs -text
+data/egm96-5.png filter=lfs diff=lfs merge=lfs -text

--- a/data/egm96-15.pgm.aux.xml
+++ b/data/egm96-15.pgm.aux.xml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:360be0474b2e069885584d2fb409597eec0d9b405ecf4804e5a369bdd842f11c
+size 1081

--- a/data/egm96-15.png
+++ b/data/egm96-15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c4f5540b666658e7842a6e83d75691d5ea97084d7a86edaf4bd0b84d0a1ef74
+size 1327767

--- a/data/egm96-15.png.aux.xml
+++ b/data/egm96-15.png.aux.xml
@@ -1,0 +1,12 @@
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Metadata>
+      <MDI key="STATISTICS_APPROXIMATE">YES</MDI>
+      <MDI key="STATISTICS_MAXIMUM">62988</MDI>
+      <MDI key="STATISTICS_MEAN">35672.185987103</MDI>
+      <MDI key="STATISTICS_MINIMUM">430</MDI>
+      <MDI key="STATISTICS_STDDEV">9679.0449921993</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>

--- a/data/egm96-15.wld
+++ b/data/egm96-15.wld
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01111aa95b2317bd3fad11c762c8708323dee9ae4e09be1e408ef9e65d3e706b
+size 50

--- a/data/egm96-5.pgm.aux.xml
+++ b/data/egm96-5.pgm.aux.xml
@@ -1,0 +1,28 @@
+<PAMDataset>
+  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]</SRS>
+  <GeoTransform> -4.1666666666666657e-02,  8.3333333333333329e-02,  0.0000000000000000e+00,  9.0041666666666671e+01,  0.0000000000000000e+00, -8.3333333333333329e-02</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Point</MDI>
+    <MDI key="DateTime">2009-08-29 18:45:03</MDI>
+    <MDI key="Description">WGS84 EGM96, 5-minute grid</MDI>
+    <MDI key="MaxBilinearError">0.140</MDI>
+    <MDI key="MaxCubicError">0.003</MDI>
+    <MDI key="Offset">-108</MDI>
+    <MDI key="RMSBilinearError">0.005</MDI>
+    <MDI key="RMSCubicError">0.001</MDI>
+    <MDI key="Scale">0.003</MDI>
+    <MDI key="Tie_Point_Location">pixel_corner</MDI>
+    <MDI key="URL">http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/egm96.html</MDI>
+    <MDI key="Vertical_Datum">WGS84</MDI>
+  </Metadata>
+  <PAMRasterBand band="1">
+    <Metadata>
+      <MDI key="STATISTICS_APPROXIMATE">YES</MDI>
+      <MDI key="STATISTICS_MAXIMUM">63642</MDI>
+      <MDI key="STATISTICS_MEAN">35659.475413712</MDI>
+      <MDI key="STATISTICS_MINIMUM">483</MDI>
+      <MDI key="STATISTICS_STDDEV">9711.9911746406</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>

--- a/data/egm96-5.png
+++ b/data/egm96-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3f14da221c06bee234b292d3e1ef356e7587f048fc8bf5ecd9c43b0030b5da6
+size 8093798

--- a/data/egm96-5.wld
+++ b/data/egm96-5.wld
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b4f5fa8fc8edc9bbfc18c67d2b2de1bd884542cbccec9b5c6f57cb7bd2895be
+size 50

--- a/data/geoids/egm96-15.pgm.aux.xml
+++ b/data/geoids/egm96-15.pgm.aux.xml
@@ -1,0 +1,28 @@
+<PAMDataset>
+  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]</SRS>
+  <GeoTransform> -1.2500000000000000e-01,  2.5000000000000000e-01,  0.0000000000000000e+00,  9.0125000000000000e+01,  0.0000000000000000e+00, -2.5000000000000000e-01</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">Point</MDI>
+    <MDI key="DateTime">2009-08-29 18:45:02</MDI>
+    <MDI key="Description">WGS84 EGM96, 15-minute grid</MDI>
+    <MDI key="MaxBilinearError">1.152</MDI>
+    <MDI key="MaxCubicError">0.169</MDI>
+    <MDI key="Offset">-108</MDI>
+    <MDI key="RMSBilinearError">0.040</MDI>
+    <MDI key="RMSCubicError">0.007</MDI>
+    <MDI key="Scale">0.003</MDI>
+    <MDI key="Tie_Point_Location">pixel_corner</MDI>
+    <MDI key="URL">http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/egm96.html</MDI>
+    <MDI key="Vertical_Datum">WGS84</MDI>
+  </Metadata>
+  <PAMRasterBand band="1">
+    <Metadata>
+      <MDI key="STATISTICS_APPROXIMATE">YES</MDI>
+      <MDI key="STATISTICS_MAXIMUM">62988</MDI>
+      <MDI key="STATISTICS_MEAN">35672.185987103</MDI>
+      <MDI key="STATISTICS_MINIMUM">430</MDI>
+      <MDI key="STATISTICS_STDDEV">9679.0449921993</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>


### PR DESCRIPTION
- raster maps are a lot faster than spherical harmonics, at the cost of memory usage and binary size