### PR TITLE
feat: bumpversion to 0.2, additional APIs for raster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.6"
+version = "0.2.0"
 description = "EGM96 altitude above WGS84 Ellipsoid"
 edition = "2021"
 license = "Zlib"


### PR DESCRIPTION
- since there are new better APIs do a version bump