### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ version = "0.2.3"
 description = "EGM96 altitude above WGS84 Ellipsoid"
 edition = "2021"
 license = "Zlib"
-homepage = "https://github.com/micahcc/egm96-rs"
+repository = "https://github.com/micahcc/egm96-rs"
 readme = "README.md"
 
 [workspace]


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88